### PR TITLE
[WIP]トップページの背景画像の修正

### DIFF
--- a/app/assets/stylesheets/protospace.css.scss
+++ b/app/assets/stylesheets/protospace.css.scss
@@ -275,7 +275,7 @@ body {
   background-position:  center 92px;
   background-repeat: no-repeat;
   background-attachment: fixed;
-  background-size:  100% auto;
+  background-size:  100% 100%;
   padding: 80px 0;
   margin-bottom: 0;
 }


### PR DESCRIPTION
# What
トップページのタイトル部分の画像の縦幅を修正。

# Why
画面の幅を変えた時に動いて見づらいから。